### PR TITLE
topic (iac): [foundry] update Azure OpenAI model from gpt-4o to gpt-4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Follow these instructions to deploy this example to your application landing zon
   - App Service Plans: P1v3 (AZ), 3 instances
   - Azure AI Search (S - Standard): 1
   - Azure Cosmos DB: 1 account
-  - Azure OpenAI in Foundry Models: GPT-4o model deployment with 50k TPM capacity
+  - Azure OpenAI in Foundry Models: GPT-4.1 model deployment with 50k TPM capacity
   - Public IPv4 Addresses - Standard: 4
   - Storage Accounts: 2
 

--- a/infra-as-code/bicep/ai-foundry.bicep
+++ b/infra-as-code/bicep/ai-foundry.bicep
@@ -86,8 +86,8 @@ resource foundry 'Microsoft.CognitiveServices/accounts@2025-10-01-preview' = {
     properties: {
       model: {
         format: 'OpenAI'
-        name: 'gpt-4o'
-        version: '2024-11-20'  // Use a model version available in your region.
+        name: 'gpt-4.1'
+        version: '2025-04-14'  // Use a model version available in your region.
       }
       versionUpgradeOption: 'NoAutoUpgrade' // Production deployments should not auto-upgrade models.  Testing compatibility is important.
       raiPolicyName: 'Microsoft.DefaultV2'  // If this isn't strict enough for your use case, create a custom RAI policy.


### PR DESCRIPTION
## WHY

gpt-4o version 2024-11-20 is scheduled for retirement on June 3, 2026. Rather than updating to a newer gpt-4o version, we're upgrading to gpt-4.1 which offers better capabilities and a longer support runway. Expected retirement for gpt-4.1 (2025-04-14) is ~Q2-Q4 2027.

## WHAT

- [x] update the deployed model from gpt-4o to gpt-4.1 in ai-foundry.bicep
- [x] update README quota reference

## TEST

Pending end-to-end validation.

Port of azure-samples/microsoft-foundry-baseline#88