### PR TITLE
patch (docs): [cert] fix domain mismatch between generated cert and app gateway listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ The following steps are required to deploy the infrastructure from the command l
      Create the certificate that will be presented to web clients by Azure Application Gateway for your domain.
 
      ```bash
-     openssl req -x509 -nodes -days 365 -newkey rsa:2048 -out appgw.crt -keyout appgw.key -subj "/CN=${DOMAIN_NAME_APPSERV}/O=Contoso" -addext "subjectAltName = DNS:${DOMAIN_NAME_APPSERV}" -addext "keyUsage = digitalSignature" -addext "extendedKeyUsage = serverAuth"
+     openssl req -x509 -nodes -days 365 -newkey rsa:2048 -out appgw.crt -keyout appgw.key -subj "/CN=www.${DOMAIN_NAME_APPSERV}/O=Contoso" -addext "subjectAltName = DNS:www.${DOMAIN_NAME_APPSERV}" -addext "keyUsage = digitalSignature" -addext "extendedKeyUsage = serverAuth"
      openssl pkcs12 -export -out appgw.pfx -in appgw.crt -inkey appgw.key -passout pass:
      ```
 


### PR DESCRIPTION
## Why

The App Gateway listener is configured with `hostName: www.${customDomainName}` and `requireServerNameIndication: true` (`infra-as-code/bicep/application-gateway.bicep` line 281-283). The self-signed certificate generated in the deployment guide uses `CN=${DOMAIN_NAME_APPSERV}` and `SAN=DNS:${DOMAIN_NAME_APPSERV}` (i.e. `contoso.com`), which does not cover `www.contoso.com`.

Per RFC 6125 §6.4.3, TLS hostname validation requires an exact match between the requested hostname and the certificate CN/SAN — no suffix or subdomain matching is performed unless a wildcard is present. A cert with `CN=contoso.com` will not match `www.contoso.com`, resulting in a TLS hostname mismatch error.

While self-signed certs are typically used with `-k` or browser warning dismissal, aligning the cert with the listener hostname ensures the deployment guide teaches the correct pattern. Users adapting this landing zone for a real domain with a CA-issued certificate would hit a hard TLS error if they followed the current example without the `www.` prefix.

## What

- [x] Update the `openssl` command in `README.md` to use `www.${DOMAIN_NAME_APPSERV}` for both CN and SAN, aligning the generated certificate with the App Gateway listener hostname.

## Test

Port of Azure-Samples/microsoft-foundry-baseline PR #90 — validated there with a full deployment to `francecentral`.