### PR TITLE
patch(infra): add WAF exclusion for AI chat request body content

### DIFF
--- a/infra-as-code/bicep/application-gateway.bicep
+++ b/infra-as-code/bicep/application-gateway.bicep
@@ -146,6 +146,38 @@ resource wafPolicy 'Microsoft.Network/ApplicationGatewayWebApplicationFirewallPo
           ruleGroupOverrides: []
         }
       ]
+      // AI chat conversations naturally contain markdown, code snippets, and special characters
+      // in assistant responses that trigger false positives across multiple OWASP rule categories
+      // (SQLi, protocol attack, XSS, etc.). The anomaly score accumulates across multi-turn
+      // conversations until WAF blocks the request (HTTP 403). This exclusion bypasses content-
+      // inspection rules for the "content" JSON field in the request body. When Azure WAF
+      // releases an AI/chat-aware rule set, revisit this exclusion.
+      exclusions: [
+        {
+          matchVariable: 'RequestArgValues'
+          selectorMatchOperator: 'Contains'
+          selector: 'content'
+          exclusionManagedRuleSets: [
+            {
+              ruleSetType: 'Microsoft_DefaultRuleSet'
+              ruleSetVersion: '2.1'
+              ruleGroups: [
+                { ruleGroupName: 'SQLI' }
+                { ruleGroupName: 'MS-ThreatIntel-SQLI' }
+                { ruleGroupName: 'PROTOCOL-ATTACK' }
+                { ruleGroupName: 'XSS' }
+                { ruleGroupName: 'RCE' }
+                { ruleGroupName: 'LFI' }
+                { ruleGroupName: 'RFI' }
+                { ruleGroupName: 'PHP' }
+                { ruleGroupName: 'MS-ThreatIntel-AppSec' }
+                { ruleGroupName: 'MS-ThreatIntel-WebShells' }
+                { ruleGroupName: 'MS-ThreatIntel-CVEs' }
+              ]
+            }
+          ]
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION

## WHY

Multi-turn AI chat conversations accumulate markdown, code snippets, backticks, and special characters in assistant responses that are echoed back in subsequent request bodies. OWASP and Microsoft Threat Intelligence rules in the Application Gateway WAF detect these as false positives (SQL injection, XSS, protocol attack, etc.). The anomaly score accumulates across turns until the WAF blocks the request with HTTP 403.

## WHAT

Added a per-field WAF exclusion on RequestArgValues containing content (the JSON field carrying conversation text) scoped to 11 Microsoft_DefaultRuleSet 2.1 rule groups:

- SQLI, MS-ThreatIntel-SQLI — markdown special chars trigger SQL injection patterns
- PROTOCOL-ATTACK — AI discussing HTTP methods (GET, POST) matches request smuggling rules
- XSS, RCE, LFI, RFI, PHP — code snippets in AI responses trigger these categories
- MS-ThreatIntel-AppSec, MS-ThreatIntel-WebShells, MS-ThreatIntel-CVEs — broad threat intel patterns

Structural rules (METHOD-ENFORCEMENT, PROTOCOL-ENFORCEMENT, SESSION-FIXATION, SESSION-JAVA) are retained — they inspect request structure, not body content.

> Note: When Azure WAF releases an AI/chat-aware rule set, this exclusion should be revisited.

## TEST

+10 turns without 403s