### PR TITLE
feat (website): [refact] migrate chatui from Foundry SDK to MAF Foundry provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If using the Foundry portal is desired, then the web browser experience must be 
 
 A chat UI application is deployed into a private Azure App Service. The UI is accessed through Application Gateway (WAF). The .NET code uses the [Microsoft Agent Framework](https://github.com/microsoft/agent-framework) with the Foundry provider to connect to the workload's agent through the project-scoped endpoint. At this scope, applications can choose between Microsoft Agent Framework or the [Foundry SDK](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/ai/Azure.AI.Projects). The project-scoped endpoint is accessed through the Foundry private endpoint within the virtual network.
 
-Agent invocation at runtime uses a different API surface than agent lifecycle management. [Microsoft Agent Framework](https://github.com/microsoft/agent-framework) uses exclusively the [OpenAI Conversations](https://learn.microsoft.com/rest/api/aifoundry/aiproject#conversations) and [Responses](https://learn.microsoft.com/rest/api/aifoundry/aiproject#responses-94) APIs, identifying the agent by name and version directly in the request body.
+Agent invocation at runtime uses a different API surface than agent lifecycle management. [Microsoft Agent Framework](https://github.com/microsoft/agent-framework) exclusively uses the [OpenAI Conversations](https://learn.microsoft.com/rest/api/aifoundry/aiproject#conversations) and [Responses](https://learn.microsoft.com/rest/api/aifoundry/aiproject#responses-94) APIs, identifying the agent by name and version directly in the request body.
 
 ## Deployment guide
 
@@ -352,7 +352,7 @@ The AI agent definition would likely be deployed from your application's pipelin
    # Deploy the agent
    az rest -u $FOUNDRY_AGENT_CREATE_URL -m "post" --resource "https://ai.azure.com" -b @chat-with-bing-output.json
 
-   # Capture the Agent's ID and Version
+   # Capture the Agent's ID and version
    $AGENT_ID="$(az rest -u $FOUNDRY_AGENT_CREATE_URL -m 'get' --resource 'https://ai.azure.com' --query last_id -o tsv)"
 
    $AGENT_VERSION="$(az rest -u $FOUNDRY_AGENT_CREATE_URL -m 'get' --resource 'https://ai.azure.com' --query 'data[-1].versions.latest.version' -o tsv)"

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Microsoft Foundry hosts the Foundry Agent Service as a capability. Foundry Agent
 
 ### Deploying an agent into Foundry Agent Service
 
-Agents can be created via the Foundry portal, Azure AI Persistent Agents client library, or the REST API. The creation and invocation of agents are a data plane operation. Since the data plane to Foundry is private, all three of those are restricted to being executed from within a private network connected to the private endpoint of Foundry.
+Project-scoped agents are created and managed through the Foundry [Agents REST API](https://learn.microsoft.com/rest/api/aifoundry/aiproject#agents), which is the underlying primitive for agent lifecycle operations. The Microsoft Foundry portal and the [Foundry SDK](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/ai/Azure.AI.Projects) consume this API. Since the data plane to Foundry is private, all of these operations are restricted to being executed from within a private network connected to the private endpoint of Foundry.
 
 Ideally agents should be source-controlled and a versioned asset. You then can deploy agents in a coordinated way with the rest of your workload's code. In this deployment guide, you'll create an agent from the jump box to simulate a deployment pipeline which could have created the agent.
 
@@ -67,7 +67,9 @@ If using the Foundry portal is desired, then the web browser experience must be 
 
 ### Invoking the agent from .NET code hosted in an Azure Web App
 
-A chat UI application is deployed into a private Azure App Service. The UI is accessed through Application Gateway (WAF). The .NET code uses the Azure AI Persistent Agents client library to connect to the workload's agent. The endpoint for the agent is exposed exclusively through the Foundry private endpoint.
+A chat UI application is deployed into a private Azure App Service. The UI is accessed through Application Gateway (WAF). The .NET code uses the [Microsoft Agent Framework](https://github.com/microsoft/agent-framework) with the Foundry provider to connect to the workload's agent through the project-scoped endpoint. At this scope, applications can choose between Microsoft Agent Framework or the [Foundry SDK](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/ai/Azure.AI.Projects). The project-scoped endpoint is accessed through the Foundry private endpoint within the virtual network.
+
+Agent invocation at runtime uses a different API surface than agent lifecycle management. [Microsoft Agent Framework](https://github.com/microsoft/agent-framework) uses exclusively the [OpenAI Conversations](https://learn.microsoft.com/rest/api/aifoundry/aiproject#conversations) and [Responses](https://learn.microsoft.com/rest/api/aifoundry/aiproject#responses-94) APIs, identifying the agent by name and version directly in the request body.
 
 ## Deployment guide
 
@@ -350,10 +352,12 @@ The AI agent definition would likely be deployed from your application's pipelin
    # Deploy the agent
    az rest -u $FOUNDRY_AGENT_CREATE_URL -m "post" --resource "https://ai.azure.com" -b @chat-with-bing-output.json
 
-   # Capture the Agent's ID
+   # Capture the Agent's ID and Version
    $AGENT_ID="$(az rest -u $FOUNDRY_AGENT_CREATE_URL -m 'get' --resource 'https://ai.azure.com' --query last_id -o tsv)"
 
+   $AGENT_VERSION="$(az rest -u $FOUNDRY_AGENT_CREATE_URL -m 'get' --resource 'https://ai.azure.com' --query 'data[-1].versions.latest.version' -o tsv)"
    echo $AGENT_ID
+   echo $AGENT_VERSION
    ```
 
 ### 3. Test the agent from the Foundry portal in the playground. *Optional.*
@@ -383,7 +387,7 @@ Here you'll test your orchestration agent by invoking it directly from the Found
 
 1. A grounded response to your question should appear on the UI.
 
-### 4. Publish the chat front-end web app
+### 4. Deploy the chat front-end web app
 
 Workloads build chat functionality into an application. Those interfaces usually call APIs which in turn call into your orchestrator. This implementation comes with such an interface. You'll deploy it to Azure App Service using its [run from package](https://learn.microsoft.com/azure/app-service/deploy-run-package) capabilities.
 
@@ -420,7 +424,7 @@ For this deployment guide, you'll continue using your jump box to simulate part 
 1. Update the app configuration to use the agent you deployed.
 
    ```powershell
-   az webapp config appsettings set -n "app-${BASE_NAME}" -g $RESOURCE_GROUP --settings AIAgentId="${AGENT_ID}"
+   az webapp config appsettings set -n "app-${BASE_NAME}" -g $RESOURCE_GROUP --settings AIAgentId="${AGENT_ID}" AIAgentVersion="${AGENT_VERSION}"
    ```
 
 1. Restart the web app to load the site code and its updated configuation.

--- a/infra-as-code/bicep/web-app.bicep
+++ b/infra-as-code/bicep/web-app.bicep
@@ -203,6 +203,7 @@ resource webApp 'Microsoft.Web/sites@2024-04-01' = {
       ApplicationInsightsAgent_EXTENSION_VERSION: '~3'
       AIProjectEndpoint:  'Not yet set' // Will be set once the agent is created
       AIAgentId: 'Not yet set' // Will be set once the agent is created
+      AIAgentVersion: 'Not yet set' // Will be set once the agent is created
       XDT_MicrosoftApplicationInsights_Mode: 'Recommended'
     }
   }

--- a/website/chatui/Configuration/ChatApiOptions.cs
+++ b/website/chatui/Configuration/ChatApiOptions.cs
@@ -9,4 +9,7 @@ public class ChatApiOptions
 
     [Required]
     public string AIAgentId { get; init; } = default!;
+
+    [Required]
+    public string AIAgentVersion { get; init; } = default!;
 }

--- a/website/chatui/Configuration/FoundryAgentResolver.cs
+++ b/website/chatui/Configuration/FoundryAgentResolver.cs
@@ -1,0 +1,42 @@
+using Azure.AI.Projects;
+using Azure.AI.Extensions.OpenAI;
+using Microsoft.Agents.AI.Foundry;
+using Microsoft.Extensions.Options;
+
+namespace chatui.Configuration;
+
+#pragma warning disable OPENAI001 // FoundryAgent is experimental
+
+public class FoundryAgentResolver : IDisposable
+{
+    private readonly AIProjectClient _projectClient;
+    private readonly IOptionsMonitor<ChatApiOptions> _options;
+    private readonly IDisposable? _changeToken;
+    private volatile FoundryAgent? _agent;
+
+    public FoundryAgentResolver(AIProjectClient projectClient, IOptionsMonitor<ChatApiOptions> options)
+    {
+        _projectClient = projectClient;
+        _options = options;
+        _changeToken = options.OnChange(_ => Interlocked.Exchange(ref _agent, null));
+    }
+
+    public FoundryAgent GetAgent()
+    {
+        var current = _agent;
+        if (current is not null)
+            return current;
+
+        var name = _options.CurrentValue.AIAgentId;
+        var version = _options.CurrentValue.AIAgentVersion;
+        var agent = _projectClient.AsAIAgent(new AgentReference(name, version));
+
+        _agent = agent;
+        return agent;
+    }
+
+    public void Dispose()
+    {
+        _changeToken?.Dispose();
+    }
+}

--- a/website/chatui/Controllers/ChatController.cs
+++ b/website/chatui/Controllers/ChatController.cs
@@ -1,62 +1,44 @@
 ﻿using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
-using Azure.AI.Projects;
-using Azure.AI.Projects.OpenAI;
-using OpenAI.Responses;
+using Microsoft.Agents.AI;
+using Microsoft.Agents.AI.Foundry;
 using chatui.Configuration;
 
 namespace chatui.Controllers;
 
+#pragma warning disable OPENAI001 // FoundryAgent is experimental
+
 [ApiController]
 [Route("[controller]/[action]")]
-
 public class ChatController(
-    AIProjectClient projectClient,
-    IOptionsMonitor<ChatApiOptions> options,
+    FoundryAgentResolver agentResolver,
     ILogger<ChatController> logger) : ControllerBase
 {
-    private readonly AIProjectClient _projectClient = projectClient;
-    private readonly IOptionsMonitor<ChatApiOptions> _options = options;
-    private readonly ILogger<ChatController> _logger = logger;
-
     // TODO: [security] Do not trust client to provide conversationId. Instead map current user to their active conversationId in your application's own state store.
     // Without this security control in place, a user can inject messages into another user's conversation.
     [HttpPost("{conversationId}")]
-    public async Task<IActionResult> Completions([FromRoute] string conversationId, [FromBody] string message)
+    public async Task<IActionResult> Responses([FromRoute] string conversationId, [FromBody] string message)
     {
         if (string.IsNullOrWhiteSpace(message))
             throw new ArgumentException("Message cannot be null, empty, or whitespace.", nameof(message));
-        _logger.LogDebug("Prompt received {Prompt}", message);
+        logger.LogDebug("Prompt received {Prompt}", message);
 
-        // MessageResponseItem is currently intended for evaluation purposes and therefore requires explicit suppression of compiler diagnostics.
-        #pragma warning disable OPENAI001
-        MessageResponseItem userMessageResponseItem = ResponseItem.CreateUserMessageItem(
-            [ResponseContentPart.CreateInputTextPart(message)]);
+        FoundryAgent agent = agentResolver.GetAgent();
 
-        var _config = _options.CurrentValue;
-        AgentRecord agentRecord = await _projectClient.Agents.GetAgentAsync(_config.AIAgentId);
-        var agent = agentRecord.Versions.Latest;
+        var innerAgent = agent.GetService<ChatClientAgent>()!;
+        var session = await innerAgent.CreateSessionAsync(conversationId);
+        var response = await agent.RunAsync(message, session);
 
-        ProjectResponsesClient responsesClient
-            = _projectClient.OpenAI.GetProjectResponsesClientForAgent(agent, conversationId);
-
-        var agentResponseItem = await responsesClient.CreateResponseAsync([userMessageResponseItem]);
-
-        var fullText = agentResponseItem.Value.GetOutputText();
-
-        return Ok(new { data = fullText });
+        return Ok(new { data = response.ToString() });
     }
 
     [HttpPost]
     public async Task<IActionResult> Conversations()
     {
         // TODO [performance efficiency] Delay creating a conversation until the first user message arrives.
-        ProjectConversationCreationOptions conversationOptions = new();
+        FoundryAgent agent = agentResolver.GetAgent();
 
-        ProjectConversation conversation
-                = await _projectClient.OpenAI.Conversations.CreateProjectConversationAsync(
-                    conversationOptions);
+        var session = await agent.CreateConversationSessionAsync();
 
-        return Ok(new { id = conversation.Id });
+        return Ok(new { id = session.ConversationId });
     }
 }

--- a/website/chatui/Program.cs
+++ b/website/chatui/Program.cs
@@ -18,6 +18,8 @@ builder.Services.AddSingleton((provider) =>
     return projectClient;
 });
 
+builder.Services.AddSingleton<FoundryAgentResolver>();
+
 builder.Services.AddControllersWithViews();
 
 builder.Services.AddCors(options =>

--- a/website/chatui/Views/Home/Index.cshtml
+++ b/website/chatui/Views/Home/Index.cshtml
@@ -205,7 +205,7 @@
         });
 
         async function sendPrompt(prompt) {
-            const response = await fetch(`/chat/completions/${conversationId}`, {
+            const response = await fetch(`/chat/responses/${conversationId}`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify(prompt)

--- a/website/chatui/appsettings.json
+++ b/website/chatui/appsettings.json
@@ -13,5 +13,6 @@
   },
   "AllowedHosts": "*",
   "AIProjectEndpoint": "https://<foundryaccount-customsubdomain-name>.services.ai.azure.com/api/projects/<foundry-project-name>",
-  "AIAgentId": ""
+  "AIAgentId": "",
+  "AIAgentVersion": ""
 }

--- a/website/chatui/chatui.csproj
+++ b/website/chatui/chatui.csproj
@@ -9,7 +9,6 @@
     <Folder Include="wwwroot\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.AI.Projects" Version="1.2.0-beta.5" />
-    <PackageReference Include="Azure.Identity" Version="1.17.1" />
+    <PackageReference Include="Microsoft.Agents.AI.Foundry" Version="1.0.0-*" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION

## WHY

The Microsoft Agent Framework (MAF) is a provider-based abstraction layer that exposes a common `AIAgent` API, allowing applications to work across different providers. In this single-agent implementation, MAF manages request-scoped sessions on the backend while the Foundry Agent Service stores conversation history and executes tools.

Adopting MAF reduces the effort required to switch providers as the endpoint strategy evolves. This also eliminates the startup API call to resolve agents — MAF accepts agent name and version directly via `AsAIAgent(AgentReference)`.

Ports baseline PRs #98, #99, #100.

## WHAT

**Backend**
- Replaced direct Foundry SDK usage with MAF's `FoundryAgent`
- Introduced `FoundryAgentResolver` singleton with config hot-reload
- Rewrote `ChatController`: `Completions` → `Responses` action
- Added `AIAgentVersion` app setting alongside existing `AIAgentId`

**Frontend**
- Updated endpoint path from `/chat/completions/` to `/chat/responses/`

**Dependencies**
- Added `Microsoft.Agents.AI.Foundry` 1.0.0
- Removed `Azure.AI.Projects`, `Azure.Identity` (now transitive)

**Infrastructure**
- `web-app.bicep`: added `AIAgentVersion` app setting

**Documentation**
- Renamed section "Publish the chat front-end web app" → "Deploy the chat front-end web app"
- Added `$AGENT_VERSION` capture in agent deployment step
- Updated `az webapp config appsettings set` to include `AIAgentVersion`
- Updated architecture descriptions to reference MAF instead of Foundry SDK
- Updated "Deploying an agent" and "Invoking the agent" sections with current SDK/API terminology

**Packaging**
- Rebuilt chatui.zip

## TEST

<img width="1752" height="1138" alt="image" src="https://github.com/user-attachments/assets/99646c96-cdf9-408a-a1d2-867ab1c53e20" />